### PR TITLE
Set Default to 1 second

### DIFF
--- a/debounce_block.py
+++ b/debounce_block.py
@@ -2,14 +2,14 @@ from collections import defaultdict
 from datetime import datetime
 from nio.block.base import Block
 from nio.block.mixins.group_by.group_by import GroupBy
-from nio.util.discovery import discoverable
 from nio.properties import TimeDeltaProperty, VersionProperty
 
 
-@discoverable
 class Debounce(GroupBy, Block):
 
-    interval = TimeDeltaProperty(title='Debounce Interval', allow_none=True)
+    interval = TimeDeltaProperty(title='Debounce Interval', allow_none=True,
+                                 default={'days': 0, 'seconds': 1,
+                                          'microseconds': 0})
     version = VersionProperty('0.1.0')
 
     def __init__(self):

--- a/debounce_block.py
+++ b/debounce_block.py
@@ -7,7 +7,7 @@ from nio.properties import TimeDeltaProperty, VersionProperty
 
 class Debounce(GroupBy, Block):
 
-    interval = TimeDeltaProperty(title='Debounce Interval', allow_none=True,
+    interval = TimeDeltaProperty(title='Debounce Interval',
                                  default={'days': 0, 'seconds': 1,
                                           'microseconds': 0})
     version = VersionProperty('0.1.0')


### PR DESCRIPTION
Seems reasonable that we would want the debounce block to showcase its expected behavior right out of the gate.

Resolves #1 